### PR TITLE
Optimise filtering cuts central PbPb Lc->pK0s

### DIFF
--- a/TreeForMVA/cutfile/PbPb2018/makeInputCutsLctoV0_PbPb2018_Central.C
+++ b/TreeForMVA/cutfile/PbPb2018/makeInputCutsLctoV0_PbPb2018_Central.C
@@ -75,8 +75,8 @@ AliRDHFCutsLctoV0 *makeInputCutsLctoV0(Int_t whichCuts=0, TString nameCuts="Lcto
         ptbins[2]=999.;
         cutsLctoV0->SetPtBins(nptbins+1,ptbins);
         Float_t cuts[nptbins][nvars]={
-            0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1,
-            0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1};
+            0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.998,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1,
+            0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.999,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1};
         Float_t** prodcutsval;
         prodcutsval=new Float_t*[nvars];
         for(Int_t ic=0;ic<nvars;ic++){prodcutsval[ic]=new Float_t[nptbins];}
@@ -87,7 +87,7 @@ AliRDHFCutsLctoV0 *makeInputCutsLctoV0(Int_t whichCuts=0, TString nameCuts="Lcto
         }
         
         cutsLctoV0->SetUseTrackSelectionWithFilterBits(kFALSE);
-        cutsLctoV0->SetMinPtCandidate(1.);
+        cutsLctoV0->SetMinPtCandidate(3.);
         cutsLctoV0->SetCuts(nvars,nptbins,prodcutsval);
         
         


### PR DESCRIPTION
Optimisation of the Lc->pK0s cuts. 
* Changing minimum pT from 1 -> 3.
* Cos pointing angle K0s 0.99 -> 0.998 (for pT < 5)
* Cos pointing angle K0s 0.99 -> 0.999 (for pT > 5)

Test on GRID: From 1.4 GB -> 150MB, with ratio efficiency ~97%
For comparison, D0 (with less branches) is ~40MB for same number of events.

If needed, some more optimisation can be done on K0s invariant mass or impact parameter K0s
